### PR TITLE
Fixing: it does not delete the mapping if the client exist the program

### DIFF
--- a/include/re_pcp.h
+++ b/include/re_pcp.h
@@ -146,7 +146,6 @@ int request_result;/* Outcome of the request */
 
 typedef void (pcp_resp_h)(int err, struct pcp_msg *msg, void *arg);
 
-int is_request_no_authorized(void);
 int pcp_request(struct pcp_request **reqp, const struct pcp_conf *conf,
 		const struct sa *pcp_server, enum pcp_opcode opcode,
 		uint32_t lifetime, const void *payload,

--- a/include/re_pcp.h
+++ b/include/re_pcp.h
@@ -142,9 +142,11 @@ struct pcp_conf {
 /* request */
 
 struct pcp_request;
+int request_result;/* Outcome of the request */
 
 typedef void (pcp_resp_h)(int err, struct pcp_msg *msg, void *arg);
 
+int is_request_no_authorized(void);
 int pcp_request(struct pcp_request **reqp, const struct pcp_conf *conf,
 		const struct sa *pcp_server, enum pcp_opcode opcode,
 		uint32_t lifetime, const void *payload,

--- a/src/pcp/request.c
+++ b/src/pcp/request.c
@@ -87,11 +87,11 @@ static void destructor(void *arg)
 	if (req->granted && req->lifetime && req->mb) {
 
 		/* set the lifetime to zero */
-		req->mb->pos = 4;
+		/*req->mb->pos = 4;
 		mbuf_write_u32(req->mb, 0);
 
 		req->mb->pos = 0;
-		(void)udp_send(req->us, &req->srv, req->mb);
+		(void)udp_send(req->us, &req->srv, req->mb);*/
 	}
 
 	tmr_cancel(&req->tmr);

--- a/src/pcp/request.c
+++ b/src/pcp/request.c
@@ -16,7 +16,6 @@
 #include <re_pcp.h>
 #include "pcp.h"
 
-
 /*
  * Defines a PCP client request
  *
@@ -152,11 +151,6 @@ static void timeout(void *arg)
 
 	req->RT = RT_next(&req->conf, req->RT);
 	tmr_start(&req->tmr, req->RT * 1000, timeout, req);
-}
-
-int is_request_no_authorized(void)
-{
-	return (request_result);
 }
 
 static void timeout_duration(void *arg)
@@ -321,7 +315,6 @@ static int pcp_vrequest(struct pcp_request **reqp, const struct pcp_conf *conf,
 	return err;
 }
 
-
 int pcp_request(struct pcp_request **reqp, const struct pcp_conf *conf,
 		const struct sa *srv, enum pcp_opcode opcode,
 		uint32_t lifetime, const void *payload,
@@ -332,6 +325,7 @@ int pcp_request(struct pcp_request **reqp, const struct pcp_conf *conf,
 	request_result = 0;
 
 	va_start(ap, optionc);
+
 	err = pcp_vrequest(reqp, conf, srv, opcode, lifetime, payload,
 			   resph, arg, optionc, ap);
 	va_end(ap);

--- a/src/pcp/request.c
+++ b/src/pcp/request.c
@@ -42,7 +42,6 @@ struct pcp_request {
 	void *arg;
 };
 
-
 /*
  * RT:   Retransmission timeout
  * IRT:  Initial retransmission time, SHOULD be 3 seconds
@@ -106,6 +105,7 @@ static void completed(struct pcp_request *req, int err, struct pcp_msg *msg)
 {
 	pcp_resp_h *resph = req->resph;
 	void *arg = req->arg;
+	request_result = 0;
 
 	tmr_cancel(&req->tmr);
 	tmr_cancel(&req->tmr_dur);
@@ -114,6 +114,7 @@ static void completed(struct pcp_request *req, int err, struct pcp_msg *msg)
 	   response handler once and never again */
 	if (err || msg->hdr.result != PCP_SUCCESS ) {
 		req->resph = NULL;
+		request_result = 1;
 	}
 
 	if (resph)
@@ -153,6 +154,10 @@ static void timeout(void *arg)
 	tmr_start(&req->tmr, req->RT * 1000, timeout, req);
 }
 
+int is_request_no_authorized(void)
+{
+	return (request_result);
+}
 
 static void timeout_duration(void *arg)
 {
@@ -324,6 +329,7 @@ int pcp_request(struct pcp_request **reqp, const struct pcp_conf *conf,
 {
 	va_list ap;
 	int err;
+	request_result = 0;
 
 	va_start(ap, optionc);
 	err = pcp_vrequest(reqp, conf, srv, opcode, lifetime, payload,


### PR DESCRIPTION
Following the PCP RFC, the mapping will have to be deleted by the user as -l 0, not by the client in the background. 
